### PR TITLE
Add initial Arduino-based PTZ head firmware skeleton

### DIFF
--- a/InputMapper.cpp
+++ b/InputMapper.cpp
@@ -1,0 +1,117 @@
+#include "InputMapper.h"
+
+#include <cmath>
+
+namespace {
+constexpr float kAxisNormalizer = 512.0f;
+constexpr float kTriggerNormalizer = 1023.0f;
+constexpr float kPanDeadzone = 0.08f;
+constexpr float kPanExpo = 0.3f;
+constexpr float kTiltDeadzone = 0.08f;
+constexpr float kTiltExpo = 0.3f;
+constexpr uint32_t kPresetSaveHoldMs = 2000;
+}
+
+InputMapper::InputMapper() = default;
+
+InputMapper::InputState InputMapper::map(const GamepadSnapshot& snapshot,
+                                         uint32_t nowMs) {
+  InputState state{};
+  state.timestampMs = nowMs;
+
+  if (!snapshot.connected) {
+    _previousButtons = 0;
+    _savePressActive = false;
+    _lastBPressMs = 0;
+    return state;
+  }
+
+  float panNormalized = applyDeadzoneAndExpo(snapshot.axisLX, kPanDeadzone, kPanExpo);
+  float tiltNormalized = applyDeadzoneAndExpo(snapshot.axisRY, kTiltDeadzone, kTiltExpo);
+
+  state.panVelocity = panNormalized;
+  state.tiltVelocity = -tiltNormalized;
+
+  float zoomIn = static_cast<float>(snapshot.triggerR2) / kTriggerNormalizer;
+  float zoomOut = static_cast<float>(snapshot.triggerL2) / kTriggerNormalizer;
+  state.zoomVelocity = zoomIn - zoomOut;
+
+  bool buttonA = (snapshot.buttons & BUTTON_A) != 0;
+  bool buttonB = (snapshot.buttons & BUTTON_B) != 0;
+  bool startPressed = (snapshot.buttons & BUTTON_START) != 0;
+
+  if (buttonA) {
+    if (!_savePressActive) {
+      _savePressActive = true;
+      _savePressStartMs = nowMs;
+    }
+  } else if (_savePressActive) {
+    if (nowMs - _savePressStartMs >= kPresetSaveHoldMs) {
+      state.presetSave = true;
+    }
+    _savePressActive = false;
+  }
+
+  bool previousB = (_previousButtons & BUTTON_B) != 0;
+  if (!previousB && buttonB) {
+    _lastBPressMs = nowMs;
+  }
+  if (previousB && !buttonB) {
+    if ((nowMs - _lastBPressMs) <= 1500) {
+      state.presetRecall = true;
+    }
+  }
+
+  bool previousStart = (_previousButtons & BUTTON_START) != 0;
+  if (!previousStart && startPressed) {
+    state.resetEncoders = true;
+  }
+
+  state.diagnosticsDump = snapshot.l3 && snapshot.r3 &&
+                          !((_previousButtons & BUTTON_THUMBL) &&
+                            (_previousButtons & BUTTON_THUMBR));
+
+  _previousButtons = snapshot.buttons;
+
+  return state;
+}
+
+GamepadSnapshot InputMapper::createSnapshotFromGamepad(GamepadPtr gamepad) {
+  GamepadSnapshot snapshot{};
+  if (!gamepad) {
+    return snapshot;
+  }
+
+  snapshot.connected = gamepad->isConnected();
+  snapshot.axisLX = gamepad->axisX();
+  snapshot.axisLY = gamepad->axisY();
+  snapshot.axisRX = gamepad->axisRX();
+  snapshot.axisRY = gamepad->axisRY();
+  snapshot.triggerL2 = gamepad->brake();
+  snapshot.triggerR2 = gamepad->throttle();
+  snapshot.buttons = gamepad->buttons();
+  snapshot.l3 = (snapshot.buttons & BUTTON_THUMBL) != 0;
+  snapshot.r3 = (snapshot.buttons & BUTTON_THUMBR) != 0;
+  snapshot.start = (snapshot.buttons & BUTTON_START) != 0;
+  snapshot.batteryLevel = gamepad->battery();
+
+  return snapshot;
+}
+
+float InputMapper::applyDeadzoneAndExpo(int16_t value, float deadzone,
+                                        float expo) const {
+  float normalized = static_cast<float>(value) / kAxisNormalizer;
+  normalized = constrain(normalized, -1.0f, 1.0f);
+
+  if (fabsf(normalized) < deadzone) {
+    return 0.0f;
+  }
+
+  float sign = normalized >= 0.0f ? 1.0f : -1.0f;
+  float magnitude = (fabsf(normalized) - deadzone) / (1.0f - deadzone);
+  magnitude = constrain(magnitude, 0.0f, 1.0f);
+
+  float expoValue = magnitude * (1.0f - expo) + powf(magnitude, 3.0f) * expo;
+  return sign * expoValue;
+}
+

--- a/InputMapper.h
+++ b/InputMapper.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <Arduino.h>
+#include <Bluepad32.h>
+
+struct GamepadSnapshot {
+  bool connected = false;
+  int16_t axisLX = 0;
+  int16_t axisLY = 0;
+  int16_t axisRX = 0;
+  int16_t axisRY = 0;
+  uint16_t triggerL2 = 0;
+  uint16_t triggerR2 = 0;
+  uint32_t buttons = 0;
+  bool l3 = false;
+  bool r3 = false;
+  bool start = false;
+  uint8_t batteryLevel = 0;
+};
+
+class InputMapper {
+ public:
+  struct InputState {
+    float panVelocity = 0.0f;
+    float tiltVelocity = 0.0f;
+    float zoomVelocity = 0.0f;
+    bool presetSave = false;
+    bool presetRecall = false;
+    bool resetEncoders = false;
+    bool diagnosticsDump = false;
+    uint32_t timestampMs = 0;
+  };
+
+  InputMapper();
+
+  InputState map(const GamepadSnapshot& snapshot, uint32_t nowMs);
+
+  static GamepadSnapshot createSnapshotFromGamepad(GamepadPtr gamepad);
+
+ private:
+  float applyDeadzoneAndExpo(int16_t value, float deadzone, float expo) const;
+
+  uint32_t _previousButtons = 0;
+  uint32_t _savePressStartMs = 0;
+  bool _savePressActive = false;
+  uint32_t _lastBPressMs = 0;
+};
+

--- a/Logger.cpp
+++ b/Logger.cpp
@@ -1,0 +1,72 @@
+#include "Logger.h"
+
+#include <stdarg.h>
+
+Stream* Logger::s_stream = nullptr;
+
+void Logger::begin(Stream* stream) {
+  s_stream = stream;
+}
+
+void Logger::log(Level level, const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vlog(level, format, args);
+  va_end(args);
+}
+
+void Logger::debug(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vlog(Level::DEBUG, format, args);
+  va_end(args);
+}
+
+void Logger::info(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vlog(Level::INFO, format, args);
+  va_end(args);
+}
+
+void Logger::warn(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vlog(Level::WARN, format, args);
+  va_end(args);
+}
+
+void Logger::error(const char* format, ...) {
+  va_list args;
+  va_start(args, format);
+  vlog(Level::ERROR, format, args);
+  va_end(args);
+}
+
+void Logger::vlog(Level level, const char* format, va_list args) {
+  if (!s_stream) {
+    return;
+  }
+
+  char buffer[192];
+  vsnprintf(buffer, sizeof(buffer), format, args);
+  s_stream->print('[');
+  s_stream->print(levelToLabel(level));
+  s_stream->print(F("] "));
+  s_stream->println(buffer);
+}
+
+const __FlashStringHelper* Logger::levelToLabel(Level level) {
+  switch (level) {
+    case Level::DEBUG:
+      return F("DBG");
+    case Level::INFO:
+      return F("INF");
+    case Level::WARN:
+      return F("WRN");
+    case Level::ERROR:
+    default:
+      return F("ERR");
+  }
+}
+

--- a/Logger.h
+++ b/Logger.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <Arduino.h>
+#include <stdarg.h>
+
+class Logger {
+ public:
+  enum class Level { DEBUG, INFO, WARN, ERROR };
+
+  static void begin(Stream* stream);
+
+  static void log(Level level, const char* format, ...);
+
+  static void debug(const char* format, ...);
+  static void info(const char* format, ...);
+  static void warn(const char* format, ...);
+  static void error(const char* format, ...);
+
+ private:
+  static void vlog(Level level, const char* format, va_list args);
+  static const __FlashStringHelper* levelToLabel(Level level);
+
+  static Stream* s_stream;
+};
+

--- a/MotionController.cpp
+++ b/MotionController.cpp
@@ -1,0 +1,163 @@
+#include "MotionController.h"
+
+#include <algorithm>
+#include <cmath>
+
+#include "Logger.h"
+
+namespace {
+constexpr uint32_t kPanMaxSpeedHz = 6000;
+constexpr uint32_t kTiltMaxSpeedHz = 6000;
+constexpr uint32_t kZoomMaxSpeedHz = 4000;
+constexpr uint32_t kPanAcceleration = 10000;
+constexpr uint32_t kTiltAcceleration = 10000;
+constexpr uint32_t kZoomAcceleration = 5000;
+constexpr float kVelocityThreshold = 0.01f;
+}
+
+MotionController::MotionController() = default;
+
+bool MotionController::begin(FastAccelStepperEngine* engine,
+                             const StepperPinBundle& pins) {
+  _engine = engine;
+  _pins = pins;
+
+  if (!_engine) {
+    return false;
+  }
+
+  _engine->init();
+
+  _panStepper = _engine->stepperConnectToPin(_pins.pan.step);
+  _tiltStepper = _engine->stepperConnectToPin(_pins.tilt.step);
+  _zoomStepper = _engine->stepperConnectToPin(_pins.zoom.step);
+
+  if (!_panStepper || !_tiltStepper || !_zoomStepper) {
+    Logger::error("Failed to attach one or more steppers");
+    return false;
+  }
+
+  configureStepper(_panStepper, _pins.pan);
+  configureStepper(_tiltStepper, _pins.tilt);
+  configureStepper(_zoomStepper, _pins.zoom);
+
+  Logger::info("MotionController initialized steppers");
+  return true;
+}
+
+void MotionController::configureStepper(FastAccelStepper* stepper,
+                                        const StepperPins& pins) {
+  if (!stepper) {
+    return;
+  }
+  stepper->setDirectionPin(pins.dir);
+  stepper->setEnablePin(pins.enable);
+  stepper->setAutoEnable(true);
+  stepper->setCurrentPosition(0);
+}
+
+void MotionController::update(const InputMapper::InputState& state) {
+  applyVelocity(_panStepper, state.panVelocity, kPanMaxSpeedHz,
+                kPanAcceleration, "pan");
+  applyVelocity(_tiltStepper, state.tiltVelocity, kTiltMaxSpeedHz,
+                kTiltAcceleration, "tilt");
+  applyVelocity(_zoomStepper, state.zoomVelocity, kZoomMaxSpeedHz,
+                kZoomAcceleration, "zoom");
+
+  if (_panStepper) {
+    _positions.panSteps = _panStepper->getCurrentPosition();
+  }
+  if (_tiltStepper) {
+    _positions.tiltSteps = _tiltStepper->getCurrentPosition();
+  }
+  if (_zoomStepper) {
+    _positions.zoomSteps = _zoomStepper->getCurrentPosition();
+  }
+}
+
+void MotionController::applyVelocity(FastAccelStepper* stepper, float velocity,
+                                     uint32_t maxSpeed, uint32_t accel,
+                                     const char* name) {
+  if (!stepper) {
+    return;
+  }
+
+  (void)name;
+
+  float magnitude = fabsf(velocity);
+  if (magnitude < kVelocityThreshold) {
+    if (stepper->isRunning()) {
+      stepper->stopMove();
+    }
+    return;
+  }
+
+  uint32_t speed = static_cast<uint32_t>(maxSpeed * magnitude);
+  speed = std::max<uint32_t>(speed, 200);
+  speed = std::min<uint32_t>(speed, maxSpeed);
+  stepper->setAcceleration(accel);
+  stepper->setSpeedInHz(speed);
+  if (velocity > 0) {
+    stepper->runForward();
+  } else {
+    stepper->runBackward();
+  }
+}
+
+void MotionController::stopAll() {
+  if (_panStepper) {
+    _panStepper->forceStop();
+    _panStepper->disableOutputs();
+  }
+  if (_tiltStepper) {
+    _tiltStepper->forceStop();
+    _tiltStepper->disableOutputs();
+  }
+  if (_zoomStepper) {
+    _zoomStepper->forceStop();
+    _zoomStepper->disableOutputs();
+  }
+}
+
+void MotionController::resetEncoders() {
+  if (_panStepper) {
+    _panStepper->setCurrentPosition(0);
+  }
+  if (_tiltStepper) {
+    _tiltStepper->setCurrentPosition(0);
+  }
+  if (_zoomStepper) {
+    _zoomStepper->setCurrentPosition(0);
+  }
+  _positions = {};
+  Logger::info("Encoder positions reset");
+}
+
+void MotionController::refreshEncoderData() {
+  // TODO: Integrate AS5600 encoder readings via I2C multiplexer
+}
+
+void MotionController::dumpDiagnostics() const {
+  Logger::info("Stepper positions pan=%ld tilt=%ld zoom=%ld", static_cast<long>(_positions.panSteps),
+               static_cast<long>(_positions.tiltSteps),
+               static_cast<long>(_positions.zoomSteps));
+}
+
+MotionController::AxisPositions MotionController::getCurrentPositions() const {
+  return _positions;
+}
+
+void MotionController::moveToPreset(const AxisPositions& target) {
+  if (_panStepper) {
+    _panStepper->moveTo(target.panSteps);
+  }
+  if (_tiltStepper) {
+    _tiltStepper->moveTo(target.tiltSteps);
+  }
+  if (_zoomStepper) {
+    _zoomStepper->moveTo(target.zoomSteps);
+  }
+  Logger::info("Recalling preset: pan=%ld tilt=%ld zoom=%ld", static_cast<long>(target.panSteps),
+               static_cast<long>(target.tiltSteps), static_cast<long>(target.zoomSteps));
+}
+

--- a/MotionController.h
+++ b/MotionController.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <Arduino.h>
+#include <FastAccelStepper.h>
+
+#include "InputMapper.h"
+
+class MotionController {
+ public:
+  struct StepperPins {
+    uint8_t step;
+    uint8_t dir;
+    uint8_t enable;
+  };
+
+  struct StepperPinBundle {
+    StepperPins pan;
+    StepperPins tilt;
+    StepperPins zoom;
+  };
+
+  struct AxisPositions {
+    int32_t panSteps = 0;
+    int32_t tiltSteps = 0;
+    int32_t zoomSteps = 0;
+  };
+
+  MotionController();
+
+  bool begin(FastAccelStepperEngine* engine, const StepperPinBundle& pins);
+
+  void update(const InputMapper::InputState& state);
+
+  void stopAll();
+
+  void resetEncoders();
+
+  void refreshEncoderData();
+
+  void dumpDiagnostics() const;
+
+  AxisPositions getCurrentPositions() const;
+
+  void moveToPreset(const AxisPositions& target);
+
+ private:
+  void configureStepper(FastAccelStepper* stepper, const StepperPins& pins);
+  void applyVelocity(FastAccelStepper* stepper, float velocity,
+                     uint32_t maxSpeed, uint32_t accel, const char* name);
+
+  FastAccelStepperEngine* _engine = nullptr;
+  StepperPinBundle _pins{};
+  FastAccelStepper* _panStepper = nullptr;
+  FastAccelStepper* _tiltStepper = nullptr;
+  FastAccelStepper* _zoomStepper = nullptr;
+  AxisPositions _positions{};
+};
+

--- a/PTZ_Head_Firmware.ino
+++ b/PTZ_Head_Firmware.ino
@@ -1,0 +1,257 @@
+#include <Arduino.h>
+#include <Bluepad32.h>
+#include <FastAccelStepper.h>
+#include "InputMapper.h"
+#include "MotionController.h"
+#include "PresetManager.h"
+#include "SafetyManager.h"
+#include "Logger.h"
+
+// Stepper pin definitions (TODO: Move to configuration file)
+constexpr uint8_t PAN_STEP_PIN = 2;
+constexpr uint8_t PAN_DIR_PIN = 3;
+constexpr uint8_t PAN_ENABLE_PIN = 4;
+constexpr uint8_t TILT_STEP_PIN = 5;
+constexpr uint8_t TILT_DIR_PIN = 6;
+constexpr uint8_t TILT_ENABLE_PIN = 7;
+constexpr uint8_t ZOOM_STEP_PIN = 8;
+constexpr uint8_t ZOOM_DIR_PIN = 9;
+constexpr uint8_t ZOOM_ENABLE_PIN = 10;
+
+constexpr size_t CONTROL_QUEUE_LENGTH = 16;
+constexpr size_t MOTION_QUEUE_LENGTH = 1;
+
+// Event structure forwarded from Bluepad32 callbacks to ControlTask
+enum class ControlEventType : uint8_t {
+  Connected,
+  Disconnected,
+  GamepadData
+};
+
+struct ControlEvent {
+  ControlEventType type;
+  GamepadPtr gamepad;
+  GamepadSnapshot snapshot;
+};
+
+// FreeRTOS handles
+TaskHandle_t g_controlTaskHandle = nullptr;
+TaskHandle_t g_motionTaskHandle = nullptr;
+TaskHandle_t g_encoderTaskHandle = nullptr;
+
+QueueHandle_t g_controlQueue = nullptr;
+QueueHandle_t g_motionQueue = nullptr;
+
+FastAccelStepperEngine g_stepperEngine;
+MotionController g_motionController;
+InputMapper g_inputMapper;
+PresetManager g_presetManager;
+SafetyManager g_safetyManager;
+
+static GamepadSnapshot g_lastSnapshot{};
+
+// Forward declarations
+void ControlTask(void* parameter);
+void MotionTask(void* parameter);
+void EncoderTask(void* parameter);
+void onConnectedGamepad(GamepadPtr gp);
+void onDisconnectedGamepad(GamepadPtr gp);
+void onGamepadData(GamepadPtr gp);
+void onGamepadDataWithContext(GamepadPtr gp, void* context);
+static void enqueueEventFromCallback(const ControlEvent& event);
+static void processGamepadData(GamepadPtr gp);
+
+void setup() {
+  Serial.begin(115200);
+  while (!Serial && millis() < 2000) {
+    delay(10);
+  }
+
+  Logger::begin(&Serial);
+  Logger::info("PTZ Head Firmware v0.1 booting...");
+
+  if (!g_motionController.begin(&g_stepperEngine, {
+          {PAN_STEP_PIN, PAN_DIR_PIN, PAN_ENABLE_PIN},
+          {TILT_STEP_PIN, TILT_DIR_PIN, TILT_ENABLE_PIN},
+          {ZOOM_STEP_PIN, ZOOM_DIR_PIN, ZOOM_ENABLE_PIN}})) {
+    Logger::warn("MotionController failed to initialize steppers");
+  }
+
+  g_presetManager.begin();
+  g_safetyManager.begin();
+  // TODO: Initialize ESPAsyncWebServer for configuration interface (v0.2)
+
+  g_controlQueue = xQueueCreate(CONTROL_QUEUE_LENGTH, sizeof(ControlEvent));
+  g_motionQueue = xQueueCreate(MOTION_QUEUE_LENGTH, sizeof(InputMapper::InputState));
+
+  if (!g_controlQueue || !g_motionQueue) {
+    Logger::error("Failed to create FreeRTOS queues");
+  }
+
+  BaseType_t controlResult = xTaskCreatePinnedToCore(
+      ControlTask, "ControlTask", 8192, nullptr, 4, &g_controlTaskHandle, 1);
+  BaseType_t motionResult = xTaskCreatePinnedToCore(
+      MotionTask, "MotionTask", 6144, nullptr, 5, &g_motionTaskHandle, 1);
+  BaseType_t encoderResult = xTaskCreatePinnedToCore(
+      EncoderTask, "EncoderTask", 4096, nullptr, 3, &g_encoderTaskHandle, 1);
+
+  if (controlResult != pdPASS || motionResult != pdPASS || encoderResult != pdPASS) {
+    Logger::error("Failed to create one or more tasks");
+  }
+
+  BP32.setup(&onConnectedGamepad, &onDisconnectedGamepad);
+#if defined(BP32_HAVE_DATA_CALLBACK) || defined(BLUEPAD32_SUPPORTS_GAMEPAD_DATA_CALLBACK)
+  BP32.setGamepadDataCallback(onGamepadDataWithContext, nullptr);
+#else
+  BP32.setGamepadDataCallback(onGamepadData);
+#endif
+  BP32.enableNewBluetoothConnections(true);
+  Logger::info("Bluepad32 initialized, waiting for controllers...");
+}
+
+void loop() {
+  BP32.update();
+  vTaskDelay(pdMS_TO_TICKS(10));
+}
+
+static void enqueueEventFromCallback(const ControlEvent& event) {
+  if (!g_controlQueue) {
+    return;
+  }
+  if (xQueueSendToBack(g_controlQueue, &event, 0) != pdTRUE) {
+    Logger::warn("Control queue full - dropping event");
+  }
+}
+
+void onConnectedGamepad(GamepadPtr gp) {
+  ControlEvent event{};
+  event.type = ControlEventType::Connected;
+  event.gamepad = gp;
+  enqueueEventFromCallback(event);
+}
+
+void onDisconnectedGamepad(GamepadPtr gp) {
+  ControlEvent event{};
+  event.type = ControlEventType::Disconnected;
+  event.gamepad = gp;
+  enqueueEventFromCallback(event);
+}
+
+void onGamepadData(GamepadPtr gp) {
+  processGamepadData(gp);
+}
+
+void onGamepadDataWithContext(GamepadPtr gp, void* /*context*/) {
+  processGamepadData(gp);
+}
+
+static void processGamepadData(GamepadPtr gp) {
+  ControlEvent event{};
+  event.type = ControlEventType::GamepadData;
+  event.gamepad = gp;
+  event.snapshot = InputMapper::createSnapshotFromGamepad(gp);
+  enqueueEventFromCallback(event);
+}
+
+void ControlTask(void* /*parameter*/) {
+  Logger::info("ControlTask started");
+  TickType_t lastWakeTime = xTaskGetTickCount();
+  const TickType_t frequency = pdMS_TO_TICKS(2);  // 500 Hz
+
+  uint32_t lastLogMs = millis();
+
+  while (true) {
+    ControlEvent event{};
+    if (xQueueReceive(g_controlQueue, &event, pdMS_TO_TICKS(5)) == pdTRUE) {
+      uint32_t nowMs = millis();
+      switch (event.type) {
+        case ControlEventType::Connected:
+          Logger::info("Gamepad connected");
+          g_safetyManager.onControllerConnected(nowMs);
+          g_lastSnapshot.connected = true;
+          break;
+        case ControlEventType::Disconnected:
+          Logger::warn("Gamepad disconnected");
+          g_safetyManager.onControllerDisconnected(nowMs);
+          g_motionController.stopAll();
+          g_lastSnapshot = {};
+          break;
+        case ControlEventType::GamepadData: {
+          g_lastSnapshot = event.snapshot;
+          g_safetyManager.onInputActivity(nowMs);
+
+          InputMapper::InputState mapped =
+              g_inputMapper.map(event.snapshot, nowMs);
+
+          if (g_motionQueue) {
+            xQueueOverwrite(g_motionQueue, &mapped);
+          }
+
+          if (mapped.presetSave) {
+            g_presetManager.saveCurrentPosition(mapped, g_motionController.getCurrentPositions());
+          }
+          if (mapped.presetRecall) {
+            g_presetManager.recallPreset(0, g_motionController);
+          }
+          if (mapped.resetEncoders) {
+            g_motionController.resetEncoders();
+          }
+          if (mapped.diagnosticsDump) {
+            g_motionController.dumpDiagnostics();
+            g_presetManager.dumpDiagnostics();
+            g_safetyManager.dumpDiagnostics();
+          }
+          break;
+        }
+      }
+    }
+
+    uint32_t nowMs = millis();
+    if (g_safetyManager.shouldForceIdle(nowMs)) {
+      InputMapper::InputState idleState{};
+      idleState.timestampMs = nowMs;
+      if (g_motionQueue) {
+        xQueueOverwrite(g_motionQueue, &idleState);
+      }
+      g_motionController.stopAll();
+    }
+
+    if (nowMs - lastLogMs >= 5000) {
+      Logger::info("Status: connected=%s battery=%u lastInput=%lu ms", g_lastSnapshot.connected ? "yes" : "no", g_lastSnapshot.batteryLevel, nowMs - g_safetyManager.lastInputTimestamp());
+      lastLogMs = nowMs;
+    }
+
+    vTaskDelayUntil(&lastWakeTime, frequency);
+  }
+}
+
+void MotionTask(void* /*parameter*/) {
+  Logger::info("MotionTask started");
+  TickType_t lastWakeTime = xTaskGetTickCount();
+  const TickType_t frequency = pdMS_TO_TICKS(1);  // 1 kHz
+  InputMapper::InputState currentState{};
+
+  while (true) {
+    if (g_motionQueue) {
+      InputMapper::InputState newState{};
+      if (xQueueReceive(g_motionQueue, &newState, 0) == pdTRUE) {
+        currentState = newState;
+      }
+    }
+
+    g_motionController.update(currentState);
+    g_safetyManager.updateHeartbeat(millis());
+    vTaskDelayUntil(&lastWakeTime, frequency);
+  }
+}
+
+void EncoderTask(void* /*parameter*/) {
+  Logger::info("EncoderTask started");
+  TickType_t lastWakeTime = xTaskGetTickCount();
+  const TickType_t frequency = pdMS_TO_TICKS(5);  // 200 Hz
+
+  while (true) {
+    g_motionController.refreshEncoderData();
+    vTaskDelayUntil(&lastWakeTime, frequency);
+  }
+}

--- a/PresetManager.cpp
+++ b/PresetManager.cpp
@@ -1,0 +1,80 @@
+#include "PresetManager.h"
+
+#include "Logger.h"
+
+namespace {
+uint32_t simpleCRC(const uint8_t* data, size_t length) {
+  uint32_t crc = 0xA5A5A5A5;
+  for (size_t i = 0; i < length; ++i) {
+    crc = (crc << 5) ^ (crc >> 27) ^ data[i];
+  }
+  return crc;
+}
+}
+
+void PresetManager::begin() {
+  if (!EEPROM.begin(kEepromSize)) {
+    Logger::warn("EEPROM init failed - presets disabled");
+  }
+}
+
+void PresetManager::saveCurrentPosition(const InputMapper::InputState& state,
+                                        const MotionController::AxisPositions& positions) {
+  (void)state;  // TODO: map button combinations to preset index
+  PresetRecord record{};
+  record.positions = positions;
+  record.crc = calculateCRC(record);
+  writePreset(0, record);
+  Logger::info("Saved preset to slot 0 (TODO: dynamic slot selection)");
+}
+
+void PresetManager::recallPreset(uint8_t index, MotionController& controller) {
+  PresetRecord record{};
+  if (!readPreset(index, &record)) {
+    Logger::warn("Preset %u invalid or empty", index);
+    return;
+  }
+  controller.moveToPreset(record.positions);
+}
+
+void PresetManager::dumpDiagnostics() const {
+  for (uint8_t i = 0; i < kMaxPresets; ++i) {
+    PresetRecord record{};
+    if (readPreset(i, &record)) {
+      Logger::info("Preset %u: pan=%ld tilt=%ld zoom=%ld", i,
+                   static_cast<long>(record.positions.panSteps),
+                   static_cast<long>(record.positions.tiltSteps),
+                   static_cast<long>(record.positions.zoomSteps));
+    }
+  }
+}
+
+uint32_t PresetManager::calculateCRC(const PresetRecord& record) const {
+  return simpleCRC(reinterpret_cast<const uint8_t*>(&record.positions),
+                   sizeof(record.positions));
+}
+
+void PresetManager::writePreset(uint8_t index, const PresetRecord& record) {
+  if (index >= kMaxPresets) {
+    return;
+  }
+  size_t offset = index * sizeof(PresetRecord);
+  EEPROM.put(offset, record);
+  if (!EEPROM.commit()) {
+    Logger::warn("EEPROM commit failed for preset %u", index);
+  }
+}
+
+bool PresetManager::readPreset(uint8_t index, PresetRecord* out) const {
+  if (!out || index >= kMaxPresets) {
+    return false;
+  }
+  size_t offset = index * sizeof(PresetRecord);
+  EEPROM.get(offset, *out);
+  if (out->crc == 0) {
+    return false;
+  }
+  uint32_t crc = calculateCRC(*out);
+  return crc == out->crc;
+}
+

--- a/PresetManager.h
+++ b/PresetManager.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <Arduino.h>
+#include <EEPROM.h>
+
+#include "InputMapper.h"
+#include "MotionController.h"
+
+class PresetManager {
+ public:
+  struct PresetRecord {
+    uint32_t crc = 0;
+    MotionController::AxisPositions positions;
+  };
+
+  void begin();
+
+  void saveCurrentPosition(const InputMapper::InputState& state,
+                           const MotionController::AxisPositions& positions);
+
+  void recallPreset(uint8_t index, MotionController& controller);
+
+  void dumpDiagnostics() const;
+
+ private:
+  uint32_t calculateCRC(const PresetRecord& record) const;
+  void writePreset(uint8_t index, const PresetRecord& record);
+  bool readPreset(uint8_t index, PresetRecord* out) const;
+
+  static constexpr uint8_t kMaxPresets = 6;
+  static constexpr size_t kEepromSize = kMaxPresets * sizeof(PresetRecord);
+};
+

--- a/SafetyManager.cpp
+++ b/SafetyManager.cpp
@@ -1,0 +1,64 @@
+#include "SafetyManager.h"
+
+#include "Logger.h"
+
+void SafetyManager::begin() {
+  _lastInputMs = millis();
+  _lastHeartbeatMs = millis();
+  _connected = false;
+  _forceIdle = true;
+}
+
+void SafetyManager::onControllerConnected(uint32_t nowMs) {
+  _connected = true;
+  _forceIdle = false;
+  _lastInputMs = nowMs;
+  _lastHeartbeatMs = nowMs;
+}
+
+void SafetyManager::onControllerDisconnected(uint32_t nowMs) {
+  _connected = false;
+  _forceIdle = true;
+  _lastInputMs = nowMs;
+}
+
+void SafetyManager::onInputActivity(uint32_t nowMs) {
+  _lastInputMs = nowMs;
+  _forceIdle = false;
+}
+
+bool SafetyManager::shouldForceIdle(uint32_t nowMs) const {
+  if (_forceIdle) {
+    return true;
+  }
+  if (!_connected) {
+    return true;
+  }
+  if ((nowMs - _lastInputMs) > (kInputTimeoutMs + kRampDownWindowMs)) {
+    return true;
+  }
+  return false;
+}
+
+void SafetyManager::updateHeartbeat(uint32_t nowMs) {
+  if (!_connected) {
+    return;
+  }
+  if ((nowMs - _lastInputMs) > (kInputTimeoutMs + kRampDownWindowMs)) {
+    _forceIdle = true;
+  }
+  if (nowMs - _lastInputMs > kHeartbeatIntervalMs) {
+    Logger::warn("Safety timeout triggered - forcing idle");
+    _forceIdle = true;
+  }
+  if (nowMs - _lastHeartbeatMs >= kHeartbeatIntervalMs) {
+    Logger::debug("Heartbeat ok");
+    _lastHeartbeatMs = nowMs;
+  }
+}
+
+void SafetyManager::dumpDiagnostics() const {
+  Logger::info("Safety: connected=%s forceIdle=%s lastInput=%lu", _connected ? "yes" : "no",
+               _forceIdle ? "yes" : "no", static_cast<unsigned long>(_lastInputMs));
+}
+

--- a/SafetyManager.h
+++ b/SafetyManager.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <Arduino.h>
+
+class SafetyManager {
+ public:
+  void begin();
+  void onControllerConnected(uint32_t nowMs);
+  void onControllerDisconnected(uint32_t nowMs);
+  void onInputActivity(uint32_t nowMs);
+  bool shouldForceIdle(uint32_t nowMs) const;
+  void updateHeartbeat(uint32_t nowMs);
+  void dumpDiagnostics() const;
+  uint32_t lastInputTimestamp() const { return _lastInputMs; }
+
+ private:
+  static constexpr uint32_t kInputTimeoutMs = 300;
+  static constexpr uint32_t kRampDownWindowMs = 150;
+  static constexpr uint32_t kHeartbeatIntervalMs = 2000;
+
+  uint32_t _lastInputMs = 0;
+  uint32_t _lastHeartbeatMs = 0;
+  bool _connected = false;
+  bool _forceIdle = false;
+};
+


### PR DESCRIPTION
## Summary
- add the main Arduino sketch that configures Bluepad32, FreeRTOS tasks, and inter-task queues
- implement input, motion, preset, safety, and logging modules aligned with the PRD, using Bluepad32 and FastAccelStepper APIs
- include stubs and TODO markers for encoder polling and future ESPAsyncWebServer integration

## Testing
- not run (Arduino tooling not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e512612ed08323b970920a4ba81c59